### PR TITLE
Feat/38 Release Notes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,7 +88,7 @@ DATABASE_URL=postgresql://bwaincell:your_password@localhost:5433/bwaincell
 # Examples: America/Los_Angeles, America/Chicago, America/New_York, UTC
 TIMEZONE=America/Los_Angeles
 
-# Discord channel ID for reminder announcements
+# Discord channel ID for all announcements
 DEFAULT_REMINDER_CHANNEL=your_channel_id_for_reminders
 
 # Milliseconds before Discord command responses are auto-deleted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `workflow_dispatch` preserved on deploy-bot.yml for emergency manual deployments
   - Release flow: tag → validate → draft release → user reviews → publish → deploy
 
+- **Release Notes Announcement** - Bot automatically announces new versions to Discord on startup (Issue #38)
+  - New `releaseAnnouncer.ts` utility compares running version against last announced version stored in `data/.last-announced-version`
+  - Extracts release notes from CHANGELOG.md and sends a rich Discord embed to `DEFAULT_REMINDER_CHANNEL`
+  - Only announces on version change — regular restarts are silent
+  - Non-fatal: all failures log warnings without blocking startup
+  - Dockerfile updated to include `package.json` and `CHANGELOG.md` in runner stage
+  - 11 unit tests covering announcements, skips, error handling, truncation, and first-deploy edge cases
+  - **Total test count: 308 tests**
+
 ### Fixed
 
 - **PostgreSQL Auto-Increment Sequence Desync** - Fixed `SequelizeUniqueConstraintError` on `/remind me` caused by sequence `reminders_id_seq` falling behind actual `max(id)` (Issue #36)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -114,6 +114,10 @@ COPY --chown=botuser:botuser backend/package.json ./backend/
 COPY --from=builder --chown=botuser:botuser /app/shared/dist ./shared/dist
 COPY --chown=botuser:botuser shared/package.json ./shared/
 
+# Copy root package.json (version) and CHANGELOG.md (release notes) for announcements
+COPY --chown=botuser:botuser package.json ./
+COPY --chown=botuser:botuser CHANGELOG.md ./
+
 # Create data and logs directories with proper permissions
 RUN mkdir -p /app/data /app/logs && \
     chown -R botuser:botuser /app

--- a/backend/src/bot.ts
+++ b/backend/src/bot.ts
@@ -22,6 +22,7 @@ import {
 import { sequelize, syncSequences } from '../database';
 // Import API server
 import { createApiServer } from './api/server';
+import { announceRelease } from '../utils/releaseAnnouncer';
 import type { Server } from 'http';
 
 // Detect test environment
@@ -162,13 +163,16 @@ function setupEventHandlers() {
     throw new Error('Client must be initialized before setting up event handlers');
   }
 
-  client!.once('clientReady', () => {
+  client!.once('clientReady', async () => {
     logger.info(`Bot logged in as ${client!.user?.tag}`);
     logBotEvent('clientReady', {
       username: client!.user?.username,
       id: client!.user?.id,
       guilds: client!.guilds.cache.size,
     });
+
+    // Announce new version if this is a fresh deployment
+    await announceRelease(client!);
   });
 
   client!.on('interactionCreate', async (interaction) => {

--- a/backend/tests/unit/utils/releaseAnnouncer.test.ts
+++ b/backend/tests/unit/utils/releaseAnnouncer.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Unit Tests: Release Announcer
+ *
+ * Tests the announceRelease() utility that posts release notes
+ * to Discord when a new version is deployed.
+ */
+
+// Mock logger BEFORE imports
+const mockLogger = {
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+};
+
+jest.mock('../../../shared/utils/logger', () => ({
+  logger: mockLogger,
+  createLogger: jest.fn(() => mockLogger),
+}));
+
+// Mock fs module
+const mockReadFileSync = jest.fn();
+const mockWriteFileSync = jest.fn();
+const mockExistsSync = jest.fn();
+const mockMkdirSync = jest.fn();
+
+jest.mock('fs', () => ({
+  readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
+  writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+  existsSync: (...args: unknown[]) => mockExistsSync(...args),
+  mkdirSync: (...args: unknown[]) => mockMkdirSync(...args),
+}));
+
+// Mock config
+jest.mock('../../../config/config', () => ({
+  __esModule: true,
+  default: {
+    settings: {
+      defaultReminderChannel: 'channel-123',
+    },
+  },
+}));
+
+import { announceRelease } from '../../../utils/releaseAnnouncer';
+
+// Helper to build a mock Discord client
+function createMockClient(channelOverrides: Record<string, unknown> = {}) {
+  const mockSend = jest.fn().mockResolvedValue({});
+  const mockChannel = {
+    id: 'channel-123',
+    send: mockSend,
+    ...channelOverrides,
+  };
+  const mockClient = {
+    channels: {
+      fetch: jest.fn().mockResolvedValue(mockChannel),
+    },
+  };
+  return { mockClient, mockChannel, mockSend };
+}
+
+// Default CHANGELOG content
+const MOCK_CHANGELOG = `# Changelog
+
+## [2.2.0] - 2026-02-17
+
+### Added
+
+- Feature X
+- Feature Y
+
+### Fixed
+
+- Bug Z
+
+## [2.1.0] - 2026-02-11
+
+### Added
+
+- Old feature
+`;
+
+describe('announceRelease()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExistsSync.mockReturnValue(true);
+  });
+
+  /**
+   * Helper: set up fs mocks for a standard announcement scenario
+   */
+  function setupFsMocks(
+    opts: {
+      version?: string;
+      lastAnnounced?: string | null;
+      changelog?: string;
+    } = {}
+  ) {
+    const version = opts.version ?? '2.2.0';
+    const changelog = opts.changelog ?? MOCK_CHANGELOG;
+
+    mockReadFileSync.mockImplementation((filePath: string) => {
+      if (filePath.includes('package.json')) {
+        return JSON.stringify({ version });
+      }
+      if (filePath.includes('.last-announced-version')) {
+        if (opts.lastAnnounced === null || opts.lastAnnounced === undefined) {
+          throw new Error('ENOENT: no such file');
+        }
+        return opts.lastAnnounced;
+      }
+      if (filePath.includes('CHANGELOG.md')) {
+        return changelog;
+      }
+      throw new Error(`Unexpected file read: ${filePath}`);
+    });
+  }
+
+  test('announces when version is newer than last announced', async () => {
+    setupFsMocks({ lastAnnounced: '2.1.0' });
+    const { mockClient, mockSend } = createMockClient();
+
+    await announceRelease(mockClient as any);
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const embedCall = mockSend.mock.calls[0][0];
+    expect(embedCall.embeds).toHaveLength(1);
+
+    const embed = embedCall.embeds[0].data;
+    expect(embed.title).toBe('Bwaincell v2.2.0 Released');
+    expect(embed.color).toBe(0x00b894);
+    expect(embed.description).toContain('Feature X');
+    expect(embed.description).toContain('Bug Z');
+
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'Release announcement sent',
+      expect.objectContaining({ version: '2.2.0' })
+    );
+  });
+
+  test('skips when version matches last announced', async () => {
+    setupFsMocks({ lastAnnounced: '2.2.0' });
+    const { mockClient, mockSend } = createMockClient();
+
+    await announceRelease(mockClient as any);
+
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  test('skips when DEFAULT_REMINDER_CHANNEL is not set', async () => {
+    // Temporarily override config
+    const configModule = require('../../../config/config');
+    const originalChannel = configModule.default.settings.defaultReminderChannel;
+    configModule.default.settings.defaultReminderChannel = undefined;
+
+    setupFsMocks({ lastAnnounced: '2.1.0' });
+    const { mockClient, mockSend } = createMockClient();
+
+    await announceRelease(mockClient as any);
+
+    expect(mockSend).not.toHaveBeenCalled();
+
+    // Restore
+    configModule.default.settings.defaultReminderChannel = originalChannel;
+  });
+
+  test('announces on first deploy (no version file)', async () => {
+    setupFsMocks({ lastAnnounced: null });
+    const { mockClient, mockSend } = createMockClient();
+
+    await announceRelease(mockClient as any);
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
+  test('announces version without notes when CHANGELOG section is missing', async () => {
+    setupFsMocks({
+      version: '9.9.9',
+      lastAnnounced: '2.1.0',
+      changelog: MOCK_CHANGELOG, // No 9.9.9 section
+    });
+    const { mockClient, mockSend } = createMockClient();
+
+    await announceRelease(mockClient as any);
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const embed = mockSend.mock.calls[0][0].embeds[0].data;
+    expect(embed.title).toBe('Bwaincell v9.9.9 Released');
+    expect(embed.description).toBeUndefined();
+  });
+
+  test('warns and skips when channel is not found', async () => {
+    setupFsMocks({ lastAnnounced: '2.1.0' });
+    const mockClient = {
+      channels: {
+        fetch: jest.fn().mockResolvedValue(null),
+      },
+    };
+
+    await announceRelease(mockClient as any);
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'Release announcement channel not found or not a text channel',
+      expect.objectContaining({ channelId: 'channel-123' })
+    );
+  });
+
+  test('warns and does not throw when channel.send() fails', async () => {
+    setupFsMocks({ lastAnnounced: '2.1.0' });
+    const { mockClient, mockSend } = createMockClient();
+    mockSend.mockRejectedValueOnce(new Error('Discord API error'));
+
+    await announceRelease(mockClient as any);
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'Failed to send release announcement (non-fatal)',
+      expect.objectContaining({ error: 'Discord API error' })
+    );
+  });
+
+  test('updates version file after successful announcement', async () => {
+    setupFsMocks({ lastAnnounced: '2.1.0' });
+    const { mockClient } = createMockClient();
+
+    await announceRelease(mockClient as any);
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('.last-announced-version'),
+      '2.2.0',
+      'utf-8'
+    );
+  });
+
+  test('does not update version file when send fails', async () => {
+    setupFsMocks({ lastAnnounced: '2.1.0' });
+    const { mockClient, mockSend } = createMockClient();
+    mockSend.mockRejectedValueOnce(new Error('send failed'));
+
+    await announceRelease(mockClient as any);
+
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  test('truncates release notes exceeding 4096 char embed limit', async () => {
+    const longNotes = '### Added\n\n' + '- Feature line\n'.repeat(500);
+    const longChangelog = `# Changelog\n\n## [2.2.0] - 2026-02-17\n\n${longNotes}\n\n## [2.1.0] - 2026-02-11\n\n### Added\n\n- Old\n`;
+
+    setupFsMocks({ lastAnnounced: '2.1.0', changelog: longChangelog });
+    const { mockClient, mockSend } = createMockClient();
+
+    await announceRelease(mockClient as any);
+
+    const embed = mockSend.mock.calls[0][0].embeds[0].data;
+    expect(embed.description.length).toBeLessThanOrEqual(4096);
+    expect(embed.description).toMatch(/\.\.\.$/);
+  });
+
+  test('creates data directory if it does not exist', async () => {
+    mockExistsSync.mockReturnValue(false);
+    setupFsMocks({ lastAnnounced: '2.1.0' });
+    const { mockClient } = createMockClient();
+
+    await announceRelease(mockClient as any);
+
+    expect(mockMkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
+  });
+});

--- a/backend/utils/releaseAnnouncer.ts
+++ b/backend/utils/releaseAnnouncer.ts
@@ -1,0 +1,115 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { Client, EmbedBuilder, TextChannel } from 'discord.js';
+import { logger } from '../shared/utils/logger';
+import config from '../config/config';
+
+/** Path to the version tracking file (persisted via Docker volume mount) */
+const VERSION_FILE = path.resolve(__dirname, '../../data/.last-announced-version');
+
+/** Path to root package.json (contains monorepo version) */
+const PACKAGE_JSON = path.resolve(__dirname, '../../package.json');
+
+/** Path to CHANGELOG.md at repository root */
+const CHANGELOG_PATH = path.resolve(__dirname, '../../CHANGELOG.md');
+
+/** Discord embed description limit */
+const EMBED_MAX_LENGTH = 4096;
+
+function getAppVersion(): string {
+  const pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON, 'utf-8'));
+  return pkg.version;
+}
+
+function getLastAnnouncedVersion(): string | null {
+  try {
+    return fs.readFileSync(VERSION_FILE, 'utf-8').trim();
+  } catch {
+    return null;
+  }
+}
+
+function setLastAnnouncedVersion(version: string): void {
+  try {
+    const dir = path.dirname(VERSION_FILE);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(VERSION_FILE, version, 'utf-8');
+  } catch (error) {
+    logger.warn('Failed to write version file (non-fatal)', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Extract release notes for a specific version from CHANGELOG.md.
+ * Looks for the section between `## [version]` and the next `## [` header.
+ */
+function extractChangelogNotes(version: string): string | null {
+  try {
+    const changelog = fs.readFileSync(CHANGELOG_PATH, 'utf-8');
+    const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const sectionRegex = new RegExp(`## \\[${escapedVersion}\\][^\\n]*\\n([\\s\\S]*?)(?=## \\[|$)`);
+    const match = changelog.match(sectionRegex);
+    if (!match || !match[1].trim()) {
+      return null;
+    }
+    return match[1].trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Announce a new release to the configured Discord channel.
+ * Compares the running version against the last announced version.
+ * Non-fatal: logs warnings on failure but never throws.
+ */
+export async function announceRelease(client: Client): Promise<void> {
+  try {
+    const channelId = config.settings.defaultReminderChannel;
+    if (!channelId) {
+      return;
+    }
+
+    const version = getAppVersion();
+    const lastAnnounced = getLastAnnouncedVersion();
+
+    if (version === lastAnnounced) {
+      return;
+    }
+
+    const notes = extractChangelogNotes(version);
+
+    const embed = new EmbedBuilder()
+      .setTitle(`Bwaincell v${version} Released`)
+      .setColor(0x00b894)
+      .setTimestamp();
+
+    if (notes) {
+      const description =
+        notes.length > EMBED_MAX_LENGTH ? notes.slice(0, EMBED_MAX_LENGTH - 3) + '...' : notes;
+      embed.setDescription(description);
+    }
+
+    const channel = await client.channels.fetch(channelId);
+    if (!channel || !('send' in channel)) {
+      logger.warn('Release announcement channel not found or not a text channel', {
+        channelId,
+      });
+      return;
+    }
+
+    await (channel as TextChannel).send({ embeds: [embed] });
+
+    setLastAnnouncedVersion(version);
+
+    logger.info('Release announcement sent', { version, channelId });
+  } catch (error) {
+    logger.warn('Failed to send release announcement (non-fatal)', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `releaseAnnouncer.ts` utility that posts release notes to Discord when a new version is deployed
- On bot startup, compares `package.json` version against `data/.last-announced-version` — if different, extracts the matching CHANGELOG.md section and sends a rich embed to `DEFAULT_REMINDER_CHANNEL`
- Regular restarts are silent (same version = no announcement). All failures are non-fatal.
- Updates Dockerfile to copy `package.json` and `CHANGELOG.md` into the runner stage for runtime access

## Test plan

- [ ] Deploy a new version and verify the bot posts a release embed to the announcements channel
- [ ] Restart the bot without a version change and confirm no duplicate announcement
- [ ] Verify first-time deployment (no `.last-announced-version` file) triggers an announcement
- [ ] Confirm bot starts normally when `DEFAULT_REMINDER_CHANNEL` is not set

Closes #38